### PR TITLE
Update deployment-ubuntu.md

### DIFF
--- a/docs/deployment-ubuntu.md
+++ b/docs/deployment-ubuntu.md
@@ -42,13 +42,13 @@ sudo nano /etc/intune2snipe/env
 Example contents (replace placeholders — see [Configuration](configuration.md) for the full list):
 
 ```bash
-AZURE_TENANT_ID="<tenant-guid>"
-AZURE_CLIENT_ID="<app-client-id>"
-AZURE_CLIENT_SECRET="<client-secret>"
+AZURE_TENANT_ID=<tenant-guid>
+AZURE_CLIENT_ID=<app-client-id>
+AZURE_CLIENT_SECRET=<client-secret>
 
-SNIPEIT_URL="https://snipe.example.com/api/v1"
-SNIPEIT_API_TOKEN="<api-token>"
-SNIPEIT_DEFAULT_STATUS="Ready to Deploy"
+SNIPEIT_URL=https://snipe.example.com/api/v1
+SNIPEIT_API_TOKEN=<api-token>
+SNIPEIT_DEFAULT_STATUS=Ready to Deploy
 
 # Optional
 # AZURE_GROUP_IDS="<group-id-1>,<group-id-2>"
@@ -58,9 +58,9 @@ SNIPEIT_DEFAULT_STATUS="Ready to Deploy"
 
 # Lifecycle + Windows Autopilot (recommended when syncing Windows)
 # SYNC_STATE_FILE=/var/lib/intune2snipe/sync-state.json
-# SNIPEIT_STATUS_PENDING_AUTOPILOT="Pending Autopilot"
-# SNIPEIT_STATUS_PENDING_RETIRE="Pending Retire"
-# SNIPEIT_STATUS_ARCHIVED="Archived"
+# SNIPEIT_STATUS_PENDING_AUTOPILOT=Pending Autopilot
+# SNIPEIT_STATUS_PENDING_RETIRE=Pending Retire
+# SNIPEIT_STATUS_ARCHIVED=Archived
 ```
 
 Lock down the file:


### PR DESCRIPTION
Removed quotes around variables in the example /etc/intune2snipe/env.  When testing with quotes, received errors from Microsoft like this (and similar errors from Snipe):  
`ValueError: OIDC Discovery failed on https://login.microsoftonline.com/“redacted”/v2.0/.well-known/openid-configuration. HTTP status: 400, Error: {"error":"invalid_tenant","error_description":"AADSTS90002: Tenant ‘\”redacted\”’ not found. Check to make sure you have the correct tenant ID and are signing into the correct cloud. Check with your subscription administrator, this may happen if there are no active subscriptions for the tenant.`